### PR TITLE
Twitch Plays: bug fixes

### DIFF
--- a/Assets/Editor/Resources/ModConfig.asset
+++ b/Assets/Editor/Resources/ModConfig.asset
@@ -13,9 +13,10 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   id: plungerButton
   title: The Plunger Button
-  description: "The Plunger Button 1.21\nA big square button saying \u201CPUSH ME!\u201D?
+  description: "The Plunger Button 1.23\nA big square button saying \u201CPUSH ME!\u201D?
     What could possibly go wrong?\n\nModule ID: plungerButton\n\nCreated by: Royal_Flu$h\nTwitchPlays
-    implemented by River\n\nManual available here: https://ktane.timwi.de/HTML/The%20Plunger%20Button.html"
-  version: 1.21
+    implemented by River\nAutosolver implemented by eXish\n\nManual available here:
+    https://ktane.timwi.de/HTML/The%20Plunger%20Button.html"
+  version: 1.23
   outputFolder: build
   previewImage: {fileID: 2800000, guid: 05525b695515a4d46adac1a6bbe318cb, type: 3}

--- a/Assets/plungerButtonScript.cs
+++ b/Assets/plungerButtonScript.cs
@@ -222,14 +222,15 @@ public class plungerButtonScript : MonoBehaviour
             button.OnInteract();
         }
         while (GetSecond() != targetReleaseTime)
-            yield return true;
-        if (timeOfPress != targetPressTime)
         {
-            // The module is in an unsolvable state and so we panic and halt the autosolver.
-            // In TP terms this just means HandlePass and yield break.
-            // Apologies for the unnecessary Panic at the Disco reference
-            PanicAtThe();
-            yield break;
+            if (timeOfPress != targetPressTime)
+            {
+                // The module is in an unsolvable state and so we panic and halt the autosolver.
+                // In TP terms this just means HandlePass and yield break.
+                PanicAtThe();
+                yield break;
+            }
+            yield return null;
         }
         button.OnInteractEnded();
     }

--- a/Assets/plungerButtonScript.cs
+++ b/Assets/plungerButtonScript.cs
@@ -26,6 +26,7 @@ public class plungerButtonScript : MonoBehaviour
     private int targetPressTime = 0;
     private int targetReleaseTime = 0;
     private bool pressed;
+    private bool heldCorrectly;
 
     private KMBombModule module;
 
@@ -121,6 +122,7 @@ public class plungerButtonScript : MonoBehaviour
         GetComponent<KMSelectable>().AddInteractionPunch();
         timeOfPress = (Bomb.GetTime() % 60) % 10;
         timeOfPress = Mathf.FloorToInt(timeOfPress);
+        heldCorrectly = timeOfPress == targetPressTime;
         Debug.LogFormat("[The Plunger Button #{0}] Current solved modules: {1}. Target press time: {2}. Actual press time: {3}.", moduleId, solvedModules, targetPressTime, timeOfPress);
         buttonAnimation.SetBool("release", false);
         buttonAnimation.SetBool("press", true);
@@ -166,7 +168,7 @@ public class plungerButtonScript : MonoBehaviour
 
     void CheckInput()
     {
-        if(targetPressTime == timeOfPress && targetReleaseTime == timeOfRelease)
+        if(heldCorrectly && targetReleaseTime == timeOfRelease)
         {
             moduleSolved = true;
             Debug.LogFormat("[The Plunger Button #{0}] Correct response. Module solved.", moduleId);
@@ -221,17 +223,15 @@ public class plungerButtonScript : MonoBehaviour
                 yield return true;
             button.OnInteract();
         }
-        while (GetSecond() != targetReleaseTime)
+        if (!heldCorrectly)
         {
-            if (timeOfPress != targetPressTime)
-            {
-                // The module is in an unsolvable state and so we panic and halt the autosolver.
-                // In TP terms this just means HandlePass and yield break.
-                PanicAtThe();
-                yield break;
-            }
-            yield return null;
+            // The module is in an unsolvable state and so we panic and halt the autosolver.
+            // In TP terms this just means HandlePass and yield break.
+            PanicAtThe();
+            yield break;
         }
+        while (GetSecond() != targetReleaseTime)
+            yield return null;
         button.OnInteractEnded();
     }
 }

--- a/Assets/plungerButtonScript.cs
+++ b/Assets/plungerButtonScript.cs
@@ -149,9 +149,10 @@ public class plungerButtonScript : MonoBehaviour
 
     void PanicAtThe()
     {
-        Debug.LogFormat("<The Plunger Button #{0}> The module has been prematurely solved.");
+        Debug.LogFormat("<The Plunger Button #{0}> The module has been prematurely solved.", moduleId);
         moduleSolved = true;
         module.HandlePass();
+        surface.material = blackMat;
         StopAllCoroutines();
     }
 


### PR DESCRIPTION
- Fix allowing release when button is not held.
- Inversely, fix allowing hold when button is already held.
- Delay TP input if the correct time is on the bomb on the same frame the command is being processed. This is necessary as frames may pass between ProcessTwitchCommand and KMSelectable.OnInteract.